### PR TITLE
creatureモデルにseed-fuで初期データ投入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,3 +47,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'carrierwave', '~> 2.0'
 gem 'mini_magick'
 gem 'ransack'
+gem 'seed-fu'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    seed-fu (2.3.9)
+      activerecord (>= 3.1)
+      activesupport (>= 3.1)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -210,6 +213,7 @@ DEPENDENCIES
   rails (~> 6.0.3, >= 6.0.3.4)
   ransack
   sass-rails (>= 6)
+  seed-fu
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/app/controllers/creatures_controller.rb
+++ b/app/controllers/creatures_controller.rb
@@ -1,0 +1,5 @@
+class CreaturesController < ApplicationController
+  def index
+    @creatures = Creature.all
+  end
+end

--- a/app/models/creature.rb
+++ b/app/models/creature.rb
@@ -1,0 +1,2 @@
+class Creature < ApplicationRecord
+end

--- a/db/fixtures/development/10_creature.rb
+++ b/db/fixtures/development/10_creature.rb
@@ -1,0 +1,8 @@
+Creature.seed(:id,
+{ id: 1, name: 'ウミガメ' },
+{ id: 2, name: 'マンタ' },
+{ id: 3, name: 'クジラ' },
+{ id: 4, name: 'イルカ' },
+{ id: 5, name: 'カマス' },
+{ id: 6, name: 'クマノミ' }
+)

--- a/db/migrate/20210220100020_create_creatures.rb
+++ b/db/migrate/20210220100020_create_creatures.rb
@@ -1,0 +1,9 @@
+class CreateCreatures < ActiveRecord::Migration[6.0]
+  def change
+    create_table :creatures do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_14_165004) do
+ActiveRecord::Schema.define(version: 2021_02_20_100020) do
 
   create_table "areas", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "creatures", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
#26 

# What
creatureモデルにgem seed-fuを使って初期データ投入

# Why
- デフォルトseedファイルではなくgem追加することで、初期データの変更を簡易化するため
- creaturesのレコードは変更する可能性はあるが、頻繁に変更するものではないため