### PR TITLE
AssetNotPrecompiledに対するエラー解除

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+//= link application.css


### PR DESCRIPTION
# What
- fix: AssetNotPrecompiledに対するエラー解除
- `app/assets/config/manifest.js` に、`//= link application.css` 一行追加

# Why
トップ画面に `Sprockets::Rails::Helper::AssetNotPrecompiled in Tops#index` エラーが出たため