### PR TITLE
deviseで作成したusersテーブルにカラム追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,7 @@ class ApplicationController < ActionController::Base
 
   protected
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: %i(name image introduction pb sns admin))
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i(name admin))
+    devise_parameter_sanitizer.permit(:account_update, keys: %i(name image introduction pb sns))
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@ class ApplicationController < ActionController::Base
   before_action :get_areas
   before_action :get_creatures
   before_action :get_features
+  before_action :configure_permitted_parameters, if: :devise_controller?
+  protect_from_forgery with: :exception
 
   def get_spots
     @spots = Spot.all
@@ -18,5 +20,10 @@ class ApplicationController < ActionController::Base
 
   def get_features
     @features = Feature.all
+  end
+
+  protected
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i(name image introduction pb sns admin))
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -3,7 +3,7 @@
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
-   <div class="field">
+  <div class="field">
     <%= f.label :name, "ユーザーネーム" %><br />
     <%= f.text_field :name, autofocus: true %>
   </div>
@@ -29,6 +29,26 @@
   <div class="field">
     <%= f.label :password_confirmation %><br />
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :image, "プロフィール画像" %><br />
+    <%= f.file_field :image, accept: "image/png,image/jpeg,image/gif", autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :introduction, "プロフィール文" %><br />
+    <%= f.text_area :introduction, autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :pb, "自己最高記録（m）" %><br />
+    <%= f.text_field :pb, autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :sns, "インスタアカウント（@不要）" %><br />
+    <%= f.text_field :sns, autofocus: true %>
   </div>
 
   <div class="field">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -3,6 +3,11 @@
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
+   <div class="field">
+    <%= f.label :name, "ユーザーネーム" %><br />
+    <%= f.text_field :name, autofocus: true %>
+  </div>
+
   <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,6 +4,11 @@
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
+    <%= f.label :name, "ユーザーネーム" %><br />
+    <%= f.text_field :name, autofocus: true %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,9 +29,6 @@
   <body>
     <%= render "shared/header" %>
 
-    <p class="notice"><%= notice %></p>
-    <p class="alert"><%= alert %></p>
-
     <%= yield %>
 
     <%= render "shared/footer" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -41,9 +41,27 @@
           </div>
         </li>
 
-        <li class="nav-item">
-          <a class="nav-link" href="#">サインイン</a>
-        </li>
+
+        <% if user_signed_in? %>
+          <!-- ログイン時 -->
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              マイページ
+            </a>
+            <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+              <%= link_to "マイページ", root_path, class: 'dropdown-item' %>
+              <%= link_to "アカウント編集", edit_user_registration_path, class: 'dropdown-item' %>
+              <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" }, class: 'dropdown-item' %>
+            </div>
+          </li>
+        <% else %>
+          <!-- 非ログイン時 -->
+          <li class="nav-item active">
+            <%= link_to "ログイン", new_user_session_path, class: 'nav-link'%>
+          </li>
+        <% end %>
+
+
       </ul>
     </div>
   </nav>

--- a/db/migrate/20210225091131_add_column_to_user.rb
+++ b/db/migrate/20210225091131_add_column_to_user.rb
@@ -1,0 +1,4 @@
+class AddColumnToUser < ActiveRecord::Migration[6.0]
+  def change
+  end
+end

--- a/db/migrate/20210225091131_add_column_to_user.rb
+++ b/db/migrate/20210225091131_add_column_to_user.rb
@@ -1,4 +1,10 @@
 class AddColumnToUser < ActiveRecord::Migration[6.0]
   def change
+    add_column :users, :name, :string, null: false, default: '', limit: 30
+    add_column :users, :image, :string
+    add_column :users, :introduction, :text, limit: 500
+    add_column :users, :pb, :string, limit: 5
+    add_column :users, :sns, :string, limit: 50
+    add_column :users, :admin, :integer, null: false, default: 0
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_25_075059) do
+ActiveRecord::Schema.define(version: 2021_02_25_091131) do
 
   create_table "areas", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -70,6 +70,12 @@ ActiveRecord::Schema.define(version: 2021_02_25_075059) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "name", limit: 30, default: "", null: false
+    t.string "image"
+    t.text "introduction"
+    t.string "pb", limit: 5
+    t.string "sns", limit: 50
+    t.integer "admin", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
#51 

# What
usersテーブルに name, image, introduction, pb, sns, admin カラム追加

# Why
- ログインユーザーのみが使える機能を実装予定のため
- コメント機能を実装予定で、どんな人からのコメントなのか見られるようにするため
- adminカラムの追加は、スポット新規投稿と編集のできる管理者を区別するため