### PR TITLE
fix: userプロフィール画像登録のため、userモデルのimageカラムとImageUploaderクラスを紐付け

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,2 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
-//= link application.css

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  mount_uploader :image, ImageUploader
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,


### PR DESCRIPTION
#54 

# What
userモデルのimageカラムとImageUploaderクラスを紐付け

# Why
userのプロフィール画像登録のため