### PR TITLE
weathersテーブル作成、初期データ投入

### DIFF
--- a/app/models/weather.rb
+++ b/app/models/weather.rb
@@ -1,0 +1,2 @@
+class Weather < ApplicationRecord
+end

--- a/db/migrate/20210227052548_create_weathers.rb
+++ b/db/migrate/20210227052548_create_weathers.rb
@@ -1,0 +1,9 @@
+class CreateWeathers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :weathers do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_25_075059) do
+ActiveRecord::Schema.define(version: 2021_02_27_052548) do
 
   create_table "areas", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -80,6 +80,12 @@ ActiveRecord::Schema.define(version: 2021_02_25_075059) do
     t.index ["name"], name: "index_users_on_name", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["sns"], name: "index_users_on_sns", unique: true
+  end
+
+  create_table "weathers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   add_foreign_key "spot_creatures", "creatures"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,6 +3,15 @@ users = User.create([
   {name: 'テストちゃん', email: 'test1@example.com', password: 'jjjjjj', password_confirmation: 'jjjjjj', admin: 'false' },
 ])
 
+weathers = Weather.create([
+  {name: '快晴'},
+  {name: '晴れ'},
+  {name: '曇り'},
+  {name: '小雨'},
+  {name: '大雨'},
+  {name: '台風'}
+])
+
 require "csv"
 
 # スポットー生物中間データ投入


### PR DESCRIPTION
#60

# What
weathersテーブル作成、初期データ投入

# Why
- 訪問日当日の状況として、口コミ投稿時に選択肢を与えるため
- ユーザが口コミを見た上でスポットに行く場合、参考となるため
- 口コミの信頼性向上のため