### PR TITLE
tidesテーブル作成、初期データ投入

### DIFF
--- a/app/models/tide.rb
+++ b/app/models/tide.rb
@@ -1,0 +1,2 @@
+class Tide < ApplicationRecord
+end

--- a/db/migrate/20210227054850_create_tides.rb
+++ b/db/migrate/20210227054850_create_tides.rb
@@ -1,0 +1,9 @@
+class CreateTides < ActiveRecord::Migration[6.0]
+  def change
+    create_table :tides do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_27_052548) do
+ActiveRecord::Schema.define(version: 2021_02_27_054850) do
 
   create_table "areas", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -60,6 +60,12 @@ ActiveRecord::Schema.define(version: 2021_02_27_052548) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["area_id"], name: "index_spots_on_area_id"
+  end
+
+  create_table "tides", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,13 @@ weathers = Weather.create([
   {name: '台風'}
 ])
 
+tides = Tide.create([
+  {name: '大潮'},
+  {name: '小潮'},
+  {name: '満潮'},
+  {name: '干潮'}
+])
+
 require "csv"
 
 # スポットー生物中間データ投入


### PR DESCRIPTION
#62 

# What
tidesテーブル作成、初期データ投入

# Why
- 訪問日当日の状況として、口コミ投稿時に選択肢を与えるため
- ユーザが口コミを見た上でスポットに行く場合、参考となるため
- 口コミの信頼性向上のため