### PR TITLE
windsテーブル作成、初期データ投入

### DIFF
--- a/app/models/wind.rb
+++ b/app/models/wind.rb
@@ -1,0 +1,2 @@
+class Wind < ApplicationRecord
+end

--- a/db/migrate/20210227072756_create_winds.rb
+++ b/db/migrate/20210227072756_create_winds.rb
@@ -1,0 +1,9 @@
+class CreateWinds < ActiveRecord::Migration[6.0]
+  def change
+    create_table :winds do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_27_054850) do
+ActiveRecord::Schema.define(version: 2021_02_27_072756) do
 
   create_table "areas", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -89,6 +89,12 @@ ActiveRecord::Schema.define(version: 2021_02_27_054850) do
   end
 
   create_table "weathers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "winds", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,6 +19,15 @@ tides = Tide.create([
   {name: '干潮'}
 ])
 
+winds = Wind.create([
+  {name: '南風'},
+  {name: '北風'},
+  {name: '東風'},
+  {name: '西風'},
+  {name: '強風'},
+  {name: '無風'}
+])
+
 require "csv"
 
 # スポットー生物中間データ投入


### PR DESCRIPTION
#63 

# What
windsテーブル作成、初期データ投入

# Why
- 訪問日当日の状況として、口コミ投稿時に選択肢を与えるため
- ユーザが口コミを見た上でスポットに行く場合、参考となるため
- 口コミの信頼性向上のため