### PR TITLE
スポット写真の複数投稿可能機能の実装

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -72,12 +72,12 @@ class SpotsController < ApplicationController
       :description,
       :postal_code,
       :address,
-      :image,
       :area_id,
       :latitude,
       :longitude,
       creature_ids: [],
-      feature_ids: []
+      feature_ids: [],
+      images: []
     )
   end
 

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -48,7 +48,14 @@ class SpotsController < ApplicationController
 
   def update
     @spot = Spot.find(params[:id])
-    if @spot.update(spot_params)
+    if params[:spot][:image_ids]
+      params[:spot][:image_ids].each do |image_id|
+        image = @spot.images.find(image_id)
+        image.purge
+      end
+    end
+    if @spot.update_attributes(spot_params)
+      flash[:success] = "編集しました"
       redirect_to spot_path(@spot.id)
     else
       render :edit

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -7,6 +7,7 @@ class Spot < ApplicationRecord
   has_many :comments
   has_many :histories, dependent: :destroy
   has_many :clips, dependent: :destroy
+  has_many_attached :images
   mount_uploader :image, ImageUploader
 
   with_options presence: true do

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -43,7 +43,7 @@
           <p>住所<%= f.text_field :address, class: "form-control" %></p>
         </div>
         <div class="form-group">
-          <p>写真<%= f.file_field :image, accept: "image/png,image/jpeg,image/gif", class: "form-control-file" %></p>
+          <p>写真<%= f.file_field :images, accept: "image/png,image/jpeg,image/gif", class: "form-control-file", multiple: true %></p>
         </div>
 
         <%= f.submit "送信", class: "btn btn-info btn-lg my-3" %>

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -42,10 +42,18 @@
         <div class="form-group">
           <p>住所<%= f.text_field :address, class: "form-control" %></p>
         </div>
-        <div class="form-group">
-          <p>写真<%= f.file_field :images, accept: "image/png,image/jpeg,image/gif", class: "form-control-file", multiple: true %></p>
-        </div>
 
+        <div class="form-group mt-5 mb-3">
+          <p>写真<%= f.file_field :images, accept: "image/png,image/jpeg,image/gif", class: "form-control-file m-3", multiple: true %></p>
+        </div>
+        <% if @spot.images.present? %>
+          <p class="mt-5">現在登録されている画像（削除するものはチェックしてください）</p>
+          <% @spot.images.each do |image| %>
+            <%= f.check_box :image_ids, {multiple: true}, image.id, false %>
+            <%= image_tag image, size:"100x100", class: 'mb-3' %> <br>
+          <% end %>
+        <% end %>
+        <p class="ml-3"><%= image_tag @spot.image.url, size:"100x100", class: 'img-fluid rounded mb-3', alt: 'Responsive image' %><span class="ml-3">初期データ</span></p>
         <%= f.submit "送信", class: "btn btn-info btn-lg my-3" %>
       </div>
     </form>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -45,41 +45,15 @@
         </div>
 
         <div class="col-md-4 order-md-1">
-          <%= image_tag @spot.image.url, class: 'img-fluid rounded', alt: 'Responsive image' %>
+          <%= image_tag @spot.image.url, class: 'img-fluid rounded mb-3', alt: 'Responsive image' %><br>
+          <% if @spot.images.attached? %>
+            <% @spot.images.each do |image| %>
+              <%= image_tag image, class: 'img-fluid rounded mb-3', alt: 'Responsive image' %> <br>
+            <% end %>
+          <% end %>
         </div>
       </div>
     </div>
 
-<%
-=begin
-%>
-    <div id="tab2" class="tab-pane">
-      <div class="container col-md-8 mx-auto">
-        <div class="row">
-          <div class="col-md-8 order-md-2">
-            <p>口コミ</p>
-          </div>
-          <div class="col-md-4 order-md-1">
-            <%= image_tag @spot.image.url, class: 'img-fluid rounded', alt: 'Responsive image' %>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div id="tab3" class="tab-pane">
-      <div class="container col-md-8 mx-auto">
-        <div class="row">
-          <div class="col-md-8 order-md-2">
-            <p>マップ</p>
-          </div>
-          <div class="col-md-4 order-md-1">
-            <%= image_tag @spot.image.url, class: 'img-fluid rounded', alt: 'Responsive image' %>
-          </div>
-        </div>
-      </div>
-    </div>
-<%
-=end
-%>
   </div>
 </section>

--- a/db/migrate/20210307081935_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210307081935_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_06_135232) do
+ActiveRecord::Schema.define(version: 2021_03_07_081935) do
+
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "areas", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -138,6 +159,7 @@ ActiveRecord::Schema.define(version: 2021_03_06_135232) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "clips", "spots"
   add_foreign_key "clips", "users"
   add_foreign_key "comments", "spots"


### PR DESCRIPTION
#89 

# What
スポット写真の複数投稿可能機能の実装

# Why
- 見た目の良い写真のみではなく、エントリーポイントや駐車場等、文章だけでは伝わりにくい情報を写真で伝えるため
- 複数写真を比較することで、スポットのイメージが湧きやすいため