### PR TITLE
fix: 非ログインユーザが「行った！行きたい！ボタン」を押した場合ログイン画面へ飛ばす

### DIFF
--- a/app/views/clips/_clip.html.erb
+++ b/app/views/clips/_clip.html.erb
@@ -1,12 +1,17 @@
 <div id="clip-<%= @spot.id %>">
-  <% if !Clip.exists?(user: current_user, spot_id: @spot.id)%>
+  <% if user_signed_in? && !Clip.exists?(user: current_user, spot_id: @spot.id) %>
     <%= link_to spot_clips_path(@spot), method: :post, class: "clips-btn clips-spot", remote: true, 'data-turbolinks':false do %>
-    <span class="clips-spot">行きたい！</span>
+      <span class="clips-spot">行きたい！</span>
+      <%= @spot.clips.length %>
+    <% end %>
+  <% elsif user_signed_in? && Clip.exists?(user: current_user, spot_id: @spot.id) %>
+    <%= link_to spot_clips_path(@spot), method: :delete, class: "clips-btn clips-delete", remote: true, 'data-turbolinks':false do %>
+      <span class="clips-delete">行きたいリストから外す</span>
       <%= @spot.clips.length %>
     <% end %>
   <% else %>
-    <%= link_to spot_clips_path(@spot), method: :delete, class: "clips-btn clips-delete", remote: true, 'data-turbolinks':false do %>
-    <span class="clips-delete">行きたいリストから外す</span>
+    <%= link_to new_user_session_path, class: "clips-btn clips-spot" do %>
+      <span class="clips-spot">行きたい！</span>
       <%= @spot.clips.length %>
     <% end %>
   <% end %>

--- a/app/views/histories/_history.html.erb
+++ b/app/views/histories/_history.html.erb
@@ -1,12 +1,17 @@
 <div id="history-<%= @spot.id %>">
-  <% if !History.exists?(user: current_user, spot_id: @spot.id)%>
+  <% if user_signed_in? && !History.exists?(user: current_user, spot_id: @spot.id) %>
     <%= link_to spot_histories_path(@spot), method: :post, class: "histories-btn histories-spot", remote: true, 'data-turbolinks':false do %>
-    <span class="histories-spot">行った！</span>
+      <span class="histories-spot">行った！</span>
+      <%= @spot.histories.length %>
+    <% end %>
+  <% elsif user_signed_in? && History.exists?(user: current_user, spot_id: @spot.id)%>
+    <%= link_to spot_histories_path(@spot), method: :delete, class: "histories-btn histories-delete", remote: true, 'data-turbolinks':false do %>
+      <span class="histories-delete">行ったリストから外す</span>
       <%= @spot.histories.length %>
     <% end %>
   <% else %>
-    <%= link_to spot_histories_path(@spot), method: :delete, class: "histories-btn histories-delete", remote: true, 'data-turbolinks':false do %>
-    <span class="histories-delete">行ったリストから外す</span>
+    <%= link_to new_user_session_path, class: "histories-btn histories-spot" do %>
+      <span class="histories-spot">行った！</span>
       <%= @spot.histories.length %>
     <% end %>
   <% end %>


### PR DESCRIPTION
#93 

# What
非ログインユーザが「行った！行きたい！ボタン」を押した場合ログイン画面へ飛ばす

# Why
- 「行った！行きたい！ボタン」を押してマイページに登録できる機能を、ログインユーザ専用の機能とするため
- 実用的な機能をログインユーザ専用にすることによって、アカウント登録へと導くため