### PR TITLE
fix: 管理者権限を持つアカウントのみがスポット管理と、他ユーザーアカウント・口コミ削除可能に

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,8 @@
 class CommentsController < ApplicationController
   before_action :authenticate_user!, except: %i[index all]
   before_action :set_comment, only: %i[index new create edit update]
+  before_action :no_current_user, only: %i[edit update]
+  before_action :no_current_user_nor_admin, only: %i[destroy]
 
   def all
     @q = Comment.ransack(params[:q])
@@ -68,5 +70,15 @@ class CommentsController < ApplicationController
       :spot_id
     )
     # .merge(user_id: current_user.id, spot_id: params[:spot_id])
+  end
+
+  def no_current_user
+    @comment = Comment.find(params[:id])
+    redirect_to root_path unless @comment.user == current_user
+  end
+
+  def no_current_user_nor_admin
+    @comment = Comment.find(params[:id])
+    redirect_to root_path unless @comment.user == current_user || current_user.admin?
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,7 @@
 class CommentsController < ApplicationController
   before_action :authenticate_user!, except: %i[index all]
-  before_action :set_comment, only: %i[index new create edit update]
+  before_action :set_spot, only: %i[index new create edit update]
+  before_action :set_comment, only: %i[edit update destroy]
   before_action :no_current_user, only: %i[edit update]
   before_action :no_current_user_nor_admin, only: %i[destroy]
 
@@ -31,12 +32,10 @@ class CommentsController < ApplicationController
   end
 
   def edit
-    @comment = Comment.find(params[:id])
     @info = "口コミを編集する"
   end
 
   def update
-    @comment = Comment.find(params[:id])
     if @comment.update(comment_params)
       redirect_to spot_comments_path
     else
@@ -45,7 +44,6 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-    @comment = Comment.find(params[:id])
     if @comment.destroy
       redirect_to spot_comments_path, alert: "削除しました"
     else
@@ -54,8 +52,12 @@ class CommentsController < ApplicationController
   end
 
   private
-  def set_comment
+  def set_spot
     @spot = Spot.find_by(id: params[:spot_id])
+  end
+
+  def set_comment
+    @comment = Comment.find(params[:id])
   end
 
   def comment_params
@@ -73,12 +75,12 @@ class CommentsController < ApplicationController
   end
 
   def no_current_user
-    @comment = Comment.find(params[:id])
+    set_comment
     redirect_to root_path unless @comment.user == current_user
   end
 
   def no_current_user_nor_admin
-    @comment = Comment.find(params[:id])
+    set_comment
     redirect_to root_path unless @comment.user == current_user || current_user.admin?
   end
 end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,4 +1,5 @@
 class SpotsController < ApplicationController
+  before_action :move_to_root, only: %i[new edit update destroy]
 
   def index
     @spots = Spot.all
@@ -86,6 +87,10 @@ class SpotsController < ApplicationController
       feature_ids: [],
       images: []
     )
+  end
+
+  def move_to_root
+    redirect_to root_path unless user_signed_in? && current_user.admin?
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,4 +7,13 @@ class UsersController < ApplicationController
     clips = Clip.where(user_id: @user.id).order(created_at: :desc).pluck(:spot_id)
     @clip_list = Spot.find(clips)
   end
+
+  def destroy
+    @user = User.find(params[:id])
+    if @user.admin != true || @user.email != 'guest@example.com'
+      @user.destroy
+      flash[:alert] = "ユーザーを削除しました"
+      redirect_to user_path(current_user.id)
+    end
+  end
 end

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -47,6 +47,10 @@
                         <%=link_to "編集", edit_spot_comment_path(comment.spot.id, comment.id), class: 'edit' %>
                         <%=link_to "削除", spot_comment_path(comment.spot.id, comment.id), method: :delete, data: {confirm: "削除しますか？"}, class: 'delete' %>
                       </span>
+                    <% elsif user_signed_in? && current_user.admin? %>
+                      <span class="comment-btn">
+                        <%=link_to "削除", spot_comment_path(comment.spot.id, comment.id), method: :delete, data: {confirm: "削除しますか？"}, class: 'delete' %>
+                      </span>
                     <% end %>
                   </li>
                 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,7 +3,11 @@
   <%= alert %>
   <section class="profile">
     <div class="to-login-page">
-      <% if !user_signed_in? %>
+      <% if user_signed_in? && current_user.admin? && ( @user.admin == true || @user.email == 'guest@example.com') %>
+        <p>管理者アカウントおよびゲストユーザーの削除はできません</p>
+      <% elsif user_signed_in? && current_user.admin? %>
+        <%= link_to "削除", user_path(@user), method: :delete, data: {confirm: "削除しますか？"} %>
+      <% elsif !user_signed_in? %>
         <%= link_to "ログインしてマイページ機能を使う", new_user_session_path %>
       <% elsif @user.id != current_user.id %>
         <%= link_to "マイページへ", user_path(current_user.id) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     post 'users/guest_sign_in', to: 'users/sessions#new_guest'
   end
 
+  delete 'users/:id', to: 'users#destroy'
   root "tops#index"
   resources :spots do
     get 'map'


### PR DESCRIPTION
#169 

# What
管理者権限を持つアカウントのみがスポット管理と、他ユーザーアカウント・口コミ削除可能に

# Why
- スポット情報の信頼性確保のため
- 不快なユーザーや口コミを削除し心地よく使えるサイトとするため