### PR TITLE
fix: Twitter・天気アイコン部分のレスポンシブ化

### DIFF
--- a/app/assets/stylesheets/pages/_spot_title.scss
+++ b/app/assets/stylesheets/pages/_spot_title.scss
@@ -19,26 +19,28 @@
     background-color: #B9D0D7;
     border-radius: 2px;
   }
-  .twitter-share-icon {
-    position: absolute;
-    right: -265px;
-  }
-  .weather {
-    position: absolute;
-    right: -400px;
-    top: -1px;
-    .weather__content--report {
-      display: inline-block;
-      margin-right: 0.2rem;
-      img {
-        max-width: 70%;
-        background-color: #ebebeb;
-        border-radius: 8px;
-        padding: 0.1rem;
+  .tw {
+    padding-right: 30px;
+    .twitter-weather {
+      margin: 0 auto;
+      .twitter-share-icon {
+        position: relative;
+        top: -3.3rem;
+        left: -1rem;
       }
-      p{
-        font-size: 0.6rem;
-        margin: 0.3rem;
+      .weather .weather__content--report {
+        display: inline-block;
+        margin-right: 0.2rem;
+        img {
+          max-width: 70%;
+          background-color: #ebebeb;
+          border-radius: 8px;
+          padding: 0.1rem;
+        }
+        p {
+          font-size: 0.6rem;
+          margin: 0;
+        }
       }
     }
   }

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -1,6 +1,19 @@
 <div class="spot-comment">
   <div class="title">
-    <h1><%= @spot.name %><%= render 'spots/twitter_share' %><%= render 'spots/weather_api' %></h1>
+    <div class="container">
+      <div class="row">
+        <div class="col-md">
+        </div>
+        <div class="col-md">
+          <h1><%= @spot.name %></h1>
+        </div>
+        <div class="col-md tw">
+          <span class="twitter-weather">
+            <%= render 'spots/twitter_share' %><%= render 'spots/weather_api' %>
+          </span>
+        </div>
+      </div>
+    </div>
   </div>
 
   <div class="col-md-5 mx-auto">

--- a/app/views/spots/_spot_title.html.erb
+++ b/app/views/spots/_spot_title.html.erb
@@ -1,3 +1,16 @@
 <div class="title">
-  <h1><%= @spot.name %><%= render 'twitter_share' %><%= render 'weather_api' %></h1>
+  <div class="container">
+    <div class="row">
+      <div class="col-md">
+      </div>
+      <div class="col-md">
+        <h1><%= @spot.name %></h1>
+      </div>
+      <div class="col-md tw">
+        <span class="twitter-weather">
+          <%= render 'twitter_share' %><%= render 'weather_api' %>
+        </span>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/spots/_weather_api.html.erb
+++ b/app/views/spots/_weather_api.html.erb
@@ -1,4 +1,4 @@
-<div class="weather">
-  <div id="weather"></div>
-</div>
+<span class="weather">
+  <span id="weather"></span>
+</span>
 <%= javascript_pack_tag 'weather_api' %>


### PR DESCRIPTION
#176 

# What
Twitterアイコンと天気アイコン部分のレスポンシブ化

# Why
- Twitter、天気アイコン部分もスマホ表示可能とするため
- 全体的にスマホ対応とするため
